### PR TITLE
feat: support windows in process_exists

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ strict = []  # Warnings are errors
 libc = "0.2.40"
 log = "0.4.1"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.45.0", features = ["Win32_System_Threading", "Win32_Foundation"] }
+
 [dev-dependencies]
 rand = "0.8.2"
 


### PR DESCRIPTION
This uses the GetExitCodeProcess api to determine whether a process for a given PID is still running on windows, where libc::kill is not defined.