### PR TITLE
fix: remove potential panics from the codebase

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,10 @@ rand = "0.8.2"
 
 [badges]
 circle-ci = { repository = "rockstar/pidlock", branch = "master" }
+
+[lints.clippy]
+expect_used = { level = "deny" }
+panic = { level = "deny" }
+print_stdout = { level = "deny" }
+undocumented_unsafe_blocks = { level = "deny" }
+unwrap_used = { level = "deny" }

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+allow-unwrap-in-tests = true


### PR DESCRIPTION
This patch removes the use of `unwrap` and `expect` from the codebase, opting for proper error handling. It also adds a number of clippy lints to enforce that these can't be reintroduced.

Additionally, it adds a new `PidlockError::IOError` for cases where I/O caused an error.

BREAKING CHANGE: `get_owner` now returns a
`Result<Option<32>, PidlockError>` to accomodate cases where an error can occur.