### PR TITLE
test: use tempfile in tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ strict = []  # Warnings are errors
 [dependencies]
 libc = "0.2.40"
 log = "0.4.1"
+tempfile = "3.21.0"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.45.0", features = [


### PR DESCRIPTION
This patch changes the tests from writing to `/tmp/...` to using `tempfile::NamedTempfile`, which cleans itself up after running.