### PR TITLE
test: add cargo-semver-checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,10 @@ jobs:
       run: cargo fmt -- --check
     - name: Run cargo deny
       run: cargo deny check
+  semver-checks:
+    name: Semver checks
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - uses: obi1kenobi/cargo-semver-checks-action@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pidlock"
-version = "0.1.6"
+version = "0.2.0"
 authors = ["Paul Hummer <paul@eventuallyanyway.com>"]
 license = "MIT"
 edition = "2024"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ use std::{fs, process};
 use log::warn;
 
 /// Errors that may occur during the `Pidlock` lifetime.
+#[non_exhaustive]
 #[derive(Debug, PartialEq)]
 pub enum PidlockError {
     #[doc = "A lock already exists"]


### PR DESCRIPTION
This patch adds the `semver-checks` action to the ci, in order to check for breaking changes.