### PR TITLE
fix: validate unsafe windows code return values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
-        # TODO: Add "Windows" to this matrix
-        os: [Ubuntu, macOS]
+        os: [Ubuntu, macOS, windows]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
This patch fixes some potential unsafe issues with the windows-specific code. For instance, `handle` could end up being `NULL`, but that value was never checked.

Additionally, it adds windows to the matrix of builds in CI.