### PR TITLE
feat: make logging optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ strict = []  # Warnings are errors
 
 [dependencies]
 libc = "0.2.40"
-log = "0.4.1"
+log = { version = "0.4.1", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.45.0", features = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::{fs, process};
 
+#[cfg(feature = "log")]
 use log::warn;
 
 /// Errors that may occur during the `Pidlock` lifetime.
@@ -181,6 +182,7 @@ impl Pidlock {
 
         let mut contents = String::new();
         if file.read_to_string(&mut contents).is_err() {
+            #[cfg(feature = "log")]
             warn!(
                 "Removing corrupted/invalid pid file at {}",
                 self.path.to_str().unwrap_or("<invalid>")
@@ -192,6 +194,7 @@ impl Pidlock {
         match contents.trim().parse::<i32>() {
             Ok(pid) if process_exists(pid) => Ok(Some(pid)),
             Ok(_) => {
+                #[cfg(feature = "log")]
                 warn!(
                     "Removing stale pid file at {}",
                     self.path.to_str().unwrap_or("<invalid>")
@@ -200,6 +203,7 @@ impl Pidlock {
                 Ok(None)
             }
             Err(_) => {
+                #[cfg(feature = "log")]
                 warn!(
                     "Removing corrupted/invalid pid file at {}",
                     self.path.to_str().unwrap_or("<invalid>")


### PR DESCRIPTION
This patch creates a `log` feature that is not enabled by default, and it is responsible for doing logs, should the user want them.