### PR TITLE
feat: expand error chaining and error types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ strict = []  # Warnings are errors
 [dependencies]
 libc = "0.2.40"
 log = { version = "0.4.1", optional = true }
+thiserror = "1.0"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.45.0", features = [

--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,3 @@
 [licenses]
 
-allow = ["MIT"]
+allow = ["MIT", "Unicode-3.0"]


### PR DESCRIPTION
This patch changes the variants of `PidlockError` to be less fragile and more descriptive. It adds a new type with variants for the possible invalid paths that can arise. It adds `thiserror` as a dependency to improve string versions. Lastly, it makes the `PartialEq` implementation a little less fragile.