### PR TITLE
refactor: use types to enforce valid state transitions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pidlock"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Paul Hummer <paul@eventuallyanyway.com>"]
 license = "MIT"
 edition = "2024"


### PR DESCRIPTION
This patch creates a new API for `Pidlock`, using rust's type system to ensure invalid state transitions are a compile time error, rather than a runtime error.

`Pidlock` is now `Pidlock<T>`, where `T` is a state, `New`, `Acquired`, or `Released`. Only `New` can be created by a user, and the specific apis allow us to transition from valid state to valid state. For more information, see the included documentation.