### PR TITLE
fix: don't use /tmp in examples and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ use pidlock::Pidlock;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a new lock
-    let mut lock = Pidlock::new_validated("/tmp/my_app.pid")?;
+    let mut lock = Pidlock::new_validated("/run/lock/my_app.pid")?;
 
     // Try to acquire the lock
     match lock.acquire() {
@@ -64,7 +64,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 use pidlock::Pidlock;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let lock = Pidlock::new_validated("/tmp/my_app.pid")?;
+    let lock = Pidlock::new_validated("/run/lock/my_app.pid")?;
 
     // Check if a lock file exists
     if lock.exists() {
@@ -105,7 +105,7 @@ use pidlock::Pidlock;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
-        let mut lock = Pidlock::new_validated("/tmp/my_app.pid")?;
+        let mut lock = Pidlock::new_validated("/run/lock/my_app.pid")?;
         lock.acquire()?;
         
         // Do work here...

--- a/examples/advanced_usage.rs
+++ b/examples/advanced_usage.rs
@@ -188,6 +188,8 @@ fn simulate_work() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn get_lock_path() -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
+    // NOTE: This example uses temp_dir() for portability and safety.
+    // In production, consider using /var/run or /run/lock/ on Linux systems.
     let temp_dir = env::temp_dir();
     let timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
 

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -23,6 +23,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap_or_else(|| "example_program".to_string());
 
     // Create lock file in system temp directory
+    // NOTE: In production, consider using /var/run or /run/lock/ on Linux systems.
     let temp_dir = env::temp_dir();
     let lock_path = temp_dir.join(format!("{}.pid", program_name));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,9 @@
 //! use std::path::Path;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! // Create a new lock (use a proper path in real code)
-//! let mut lock = Pidlock::new_validated("/tmp/my_app.pid")?;
+//! let temp_dir = std::env::temp_dir();
+//! let lock_path = temp_dir.join("my_app.pid");
+//! let mut lock = Pidlock::new_validated(&lock_path)?;
 //!
 //! // Try to acquire the lock
 //! match lock.acquire() {
@@ -30,6 +31,7 @@
 //!         
 //!         // Explicitly release the lock (optional - it's auto-released on drop)
 //!         lock.release()?;
+//!         println!("Lock released successfully!");
 //!     }
 //!     Err(pidlock::PidlockError::LockExists) => {
 //!         println!("Another instance is already running");
@@ -50,7 +52,9 @@
 //! use pidlock::Pidlock;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! let lock = Pidlock::new_validated("/tmp/my_app.pid")?;
+//! let temp_dir = std::env::temp_dir();
+//! let lock_path = temp_dir.join("example.pid");
+//! let lock = Pidlock::new_validated(&lock_path)?;
 //!
 //! // Check if a lock file exists
 //! if lock.exists() {
@@ -89,6 +93,8 @@
 //! - **Windows**: Uses Win32 APIs for process detection, handles reserved filenames
 //! - **File permissions**: Lock files are created with restrictive permissions (600 on Unix)
 //! - **Path validation**: Automatically validates paths for cross-platform compatibility
+//! - **Lock file locations**: Use `/run/lock/` on Linux, `/var/run/` on other Unix systems,
+//!   or appropriate system directories. Avoid `/tmp` for production use.
 //!
 //! ## Safety
 //!


### PR DESCRIPTION
This patch updates the examples and docs to use `/run/lock` instead of `/tmp` for pidfile locations. The tests still use `/tmp` as we need a common, writable place for tests to execute.

Thanks to @linsomniac for the tip.