### PR TITLE
refactor: use nix crate rather than the unsafe libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,11 @@ include = ["src/*.rs", "Cargo.toml", "README.md", "LICENSE-MIT"]
 default = []
 
 [dependencies]
-libc = "0.2"
 log = { version = "0.4", optional = true }
 thiserror = "1.0"
+
+[target.'cfg(not(windows))'.dependencies]
+nix = { version = "0.30.1", features = ["signal"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.45.0", features = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -446,15 +446,9 @@ fn process_exists(pid: i32) -> bool {
 
     #[cfg(not(target_os = "windows"))]
     {
-        // SAFETY: libc::kill with signal 0 is safe when called with a valid PID because:
-        // - Signal 0 (null signal) performs no actual signal delivery
-        // - It only checks if the process exists and we have permission to signal it
-        // - POSIX guarantees this is a safe operation that won't affect the target process
-        // - We've already validated the PID is within reasonable bounds
-        unsafe {
-            let result = libc::kill(pid, 0);
-            result == 0
-        }
+        // We specify None as the signal, which equates to using 0 in `kill(2)`. This
+        // means no signal is sent, but error checking is still performed.
+        nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None).is_ok()
     }
 }
 


### PR DESCRIPTION
This patch changes the unix system call handling to use `nix` instead of `libc` interface, so the `nix` provides a safe interface to the `libc` api.